### PR TITLE
Add reauthentication support to supernote

### DIFF
--- a/custom_components/supernote_cloud/__init__.py
+++ b/custom_components/supernote_cloud/__init__.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 import logging
 
-from supernote.client.api import Supernote
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, CONF_HOST, DEFAULT_HOST
-from .auth import ConfigEntryAuth
+from .const import DOMAIN
+from .api import async_get_supernote_client
 from .types import SupernoteCloudConfigEntry
 from .media_source import async_register_http_views
 
@@ -36,12 +33,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: SupernoteCloudConfigEntry
 ) -> bool:
     """Set up a config entry."""
-
-    session = aiohttp_client.async_get_clientsession(hass)
-    host = entry.options.get(CONF_HOST, DEFAULT_HOST)
-    auth = ConfigEntryAuth(hass, entry, session)
-    sn = Supernote.from_auth(auth, host=host, session=session)
-
+    sn = await async_get_supernote_client(hass, entry)
     entry.runtime_data = sn
 
     await hass.config_entries.async_forward_entry_setups(

--- a/custom_components/supernote_cloud/api.py
+++ b/custom_components/supernote_cloud/api.py
@@ -1,0 +1,20 @@
+"""Supernote Cloud API client helper."""
+
+from supernote.client.api import Supernote
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .auth import ConfigEntryAuth
+from .const import CONF_HOST, DEFAULT_HOST
+
+
+async def async_get_supernote_client(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Supernote:
+    """Get an authenticated Supernote API client."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    host = entry.options.get(CONF_HOST, DEFAULT_HOST)
+    auth = ConfigEntryAuth(hass, entry, session)
+    return Supernote.from_auth(auth, host=host, session=session)

--- a/custom_components/supernote_cloud/auth.py
+++ b/custom_components/supernote_cloud/auth.py
@@ -9,7 +9,7 @@ import aiohttp
 from supernote.client.auth import AbstractAuth
 from supernote.client.login_client import LoginClient
 from supernote.client.client import Client
-from supernote.client.exceptions import SupernoteException
+from supernote.client.exceptions import SupernoteException, UnauthorizedException
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -38,9 +38,9 @@ class ConfigEntryAuth(AbstractAuth):
         host = entry.options.get(CONF_HOST, DEFAULT_HOST)
         self._login_client = LoginClient(Client(session, host=host))
 
-    async def async_get_access_token(self) -> str:
+    async def async_get_access_token(self, force_refresh: bool = False) -> str:
         """Return a valid access token."""
-        if self.is_expired():
+        if force_refresh or self.is_expired():
             await self._refresh_access_token()
         return cast(str, self._entry.options[CONF_ACCESS_TOKEN])
 
@@ -61,6 +61,10 @@ class ConfigEntryAuth(AbstractAuth):
             new_token = await self._login_client.login(
                 self._entry.options[CONF_USERNAME], self._entry.options[CONF_PASSWORD]
             )
+        except UnauthorizedException as err:
+            _LOGGER.debug("Login unauthorized: %s", err)
+            self._entry.async_start_reauth(self._hass)
+            raise ConfigEntryAuthFailed("Invalid credentials") from err
         except SupernoteException as err:
             _LOGGER.debug("Login api exception: %s", err)
             if "verification code" in str(err):

--- a/custom_components/supernote_cloud/auth.py
+++ b/custom_components/supernote_cloud/auth.py
@@ -38,9 +38,9 @@ class ConfigEntryAuth(AbstractAuth):
         host = entry.options.get(CONF_HOST, DEFAULT_HOST)
         self._login_client = LoginClient(Client(session, host=host))
 
-    async def async_get_access_token(self, force_refresh: bool = False) -> str:
+    async def async_get_access_token(self) -> str:
         """Return a valid access token."""
-        if force_refresh or self.is_expired():
+        if self.is_expired():
             await self._refresh_access_token()
         return cast(str, self._entry.options[CONF_ACCESS_TOKEN])
 

--- a/custom_components/supernote_cloud/config_flow.py
+++ b/custom_components/supernote_cloud/config_flow.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_API_USERNAME,
     CONF_TOKEN_TIMESTAMP,
     CONF_HOST,
+    DEFAULT_HOST,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -110,10 +111,16 @@ class SupernoteCloudConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST): selector.TextSelector(
+                    vol.Required(
+                        CONF_HOST,
+                        default=self._host or DEFAULT_HOST,
+                    ): selector.TextSelector(
                         selector.TextSelectorConfig(),
                     ),
-                    vol.Required(CONF_USERNAME): selector.TextSelector(
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=self._username or "",
+                    ): selector.TextSelector(
                         selector.TextSelectorConfig(),
                     ),
                     vol.Required(CONF_PASSWORD): selector.TextSelector(
@@ -219,6 +226,12 @@ class SupernoteCloudConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
+        reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if reauth_entry:
+            self._host = reauth_entry.options.get(CONF_HOST)
+            self._username = reauth_entry.options.get(CONF_USERNAME)
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(

--- a/custom_components/supernote_cloud/llm.py
+++ b/custom_components/supernote_cloud/llm.py
@@ -6,6 +6,7 @@ import logging
 import voluptuous as vol
 import slugify
 from supernote.client.extended import ExtendedClient
+from supernote.client.exceptions import UnauthorizedException
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -89,6 +90,9 @@ class SearchTool(Tool):
                 date_after=args.get("date_after"),
                 date_before=args.get("date_before"),
             )
+        except UnauthorizedException as err:
+            self._entry.async_start_reauth(hass)
+            return {"error": f"Supernote authentication failed: {err}"}
         except Exception as err:
             return {"error": f"Error searching Supernote: {err}"}
 
@@ -150,6 +154,9 @@ class TranscriptTool(Tool):
                 start_index=args.get("start_index"),
                 end_index=args.get("end_index"),
             )
+        except UnauthorizedException as err:
+            self._entry.async_start_reauth(hass)
+            return {"error": f"Supernote authentication failed: {err}"}
         except Exception as err:
             return {"error": f"Error fetching Supernote transcript: {err}"}
 

--- a/custom_components/supernote_cloud/media_source.py
+++ b/custom_components/supernote_cloud/media_source.py
@@ -280,7 +280,7 @@ class SupernoteCloudMediaSource(MediaSource):
                     identifier = SupernoteIdentifier.of(item.identifier)
                     entry = self._async_config_entry(identifier.config_entry_id)
                     entry.async_start_reauth(self.hass)
-                except Exception:
+                except (ValueError, BrowseError):
                     pass
             raise BrowseError("Authentication failed") from err
 

--- a/custom_components/supernote_cloud/media_source.py
+++ b/custom_components/supernote_cloud/media_source.py
@@ -8,7 +8,7 @@ import logging
 from typing import Self, cast
 
 from supernote.client.api import Supernote
-from supernote.client.exceptions import ApiException
+from supernote.client.exceptions import ApiException, UnauthorizedException
 from supernote.models.base import BooleanEnum
 from aiohttp.web import Response, Request, StreamResponse
 
@@ -192,6 +192,10 @@ class ItemContentView(HomeAssistantView):
             folder_contents = await sn.device.list_folder(
                 folder_id=identifier.parent_folder_id
             )
+        except UnauthorizedException as err:
+            _LOGGER.error("Authentication failed during folder list: %s", err)
+            entry.async_start_reauth(self.hass)
+            return Response(status=401, text=str(err))
         except ApiException as err:
             _LOGGER.error("Failed to fetch folder contents: %s", err)
             return Response(status=500, text=str(err))
@@ -230,6 +234,10 @@ class ItemContentView(HomeAssistantView):
 
             content = await sn.client.get_content(page_vo.url)
             return Response(body=content, content_type="image/png")
+        except UnauthorizedException as err:
+            _LOGGER.error("Authentication failed during note download: %s", err)
+            entry.async_start_reauth(self.hass)
+            return Response(status=401, text=str(err))
         except ApiException as err:
             _LOGGER.error("Failed to fetch note content: %s", err)
             return Response(status=500, text=str(err))
@@ -262,6 +270,21 @@ class SupernoteCloudMediaSource(MediaSource):
         )
 
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
+        """Return details about the media source."""
+        try:
+            return await self._async_browse_media(item)
+        except UnauthorizedException as err:
+            _LOGGER.error("Authentication failed: %s", err)
+            if item.identifier:
+                try:
+                    identifier = SupernoteIdentifier.of(item.identifier)
+                    entry = self._async_config_entry(identifier.config_entry_id)
+                    entry.async_start_reauth(self.hass)
+                except Exception:
+                    pass
+            raise BrowseError("Authentication failed") from err
+
+    async def _async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return details about the media source.
 
         This renders the multi-level album structure for an account, its folders,
@@ -315,6 +338,8 @@ class SupernoteCloudMediaSource(MediaSource):
                         if path_info.path
                         else f"Folder {identifier.media_id}"
                     )
+                except UnauthorizedException:
+                    raise
                 except ApiException:
                     name = f"Folder {identifier.media_id}"
 
@@ -329,6 +354,8 @@ class SupernoteCloudMediaSource(MediaSource):
                 folder_contents_vo = await sn.web.list_query(
                     directory_id=identifier.media_id, page_size=100
                 )
+            except UnauthorizedException:
+                raise
             except ApiException as err:
                 raise BrowseError(f"Failed to fetch folder contents: {err}") from err
 
@@ -373,6 +400,8 @@ class SupernoteCloudMediaSource(MediaSource):
             parent_folder_contents_vo = await sn.web.list_query(
                 directory_id=identifier.parent_folder_id, page_size=100
             )
+        except UnauthorizedException:
+            raise
         except ApiException as err:
             raise BrowseError(f"Failed to fetch parent folder contents: {err}") from err
 
@@ -399,6 +428,8 @@ class SupernoteCloudMediaSource(MediaSource):
             # PngPageVO has url.
             page_count = len(conversion_res.png_page_vo_list)
             page_names = [f"Page {i + 1}" for i in range(page_count)]
+        except UnauthorizedException:
+            raise
         except ApiException as err:
             raise BrowseError(f"Failed to get note info: {err}") from err
         _LOGGER.debug("Note has %s pages", len(page_names))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ def mock_supernote_fixture() -> Generator[AsyncMock, None, None]:
         mock_sn.device.get_capacity = AsyncMock()
         mock_sn.device.list_folder = AsyncMock()
         mock_sn.client.get_content = AsyncMock()
+        mock_sn.client.request = AsyncMock()
 
         # Class methods
         mock_sn_cls.login = AsyncMock(return_value=mock_sn)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -143,6 +143,15 @@ async def test_reauth_flow(
     assert len(entries) == 1
     old_timestamp = config_entry.options[CONF_TOKEN_TIMESTAMP]
 
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={
+            **config_entry.options,
+            CONF_USERNAME: "reauth-user-name",
+            CONF_HOST: "https://custom-host.local",
+        },
+    )
+
     config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
@@ -158,6 +167,12 @@ async def test_reauth_flow(
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "user"
+
+    schema = result["data_schema"].schema
+    host_key = next(k for k in schema if k == CONF_HOST)
+    username_key = next(k for k in schema if k == CONF_USERNAME)
+    assert host_key.default() == "https://custom-host.local"
+    assert username_key.default() == "reauth-user-name"
 
     with patch(
         f"custom_components.{DOMAIN}.async_setup_entry", return_value=True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,29 @@
-"""Tests for the supernote_cloud component."""
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.setup import async_setup_component
 
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
+)
+
+from supernote.client.exceptions import UnauthorizedException
+from custom_components.supernote_cloud.const import DOMAIN
+
+
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_UNIQUE_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.util import dt as dt_util
+from custom_components.supernote_cloud.const import (
+    CONF_TOKEN_TIMESTAMP,
+    CONF_API_USERNAME,
 )
 
 
@@ -25,3 +42,53 @@ async def test_init(
     assert (
         config_entry.state is ConfigEntryState.NOT_LOADED  # type: ignore[comparison-overlap]
     )
+
+
+async def test_api_unauthorized_triggers_reauth(
+    hass: HomeAssistant,
+    mock_supernote: MagicMock,
+) -> None:
+    """Test that an UnauthorizedException during API calls triggers reauth."""
+    from homeassistant.components.media_source.helper import async_browse_media
+    from homeassistant.components.media_player.errors import BrowseError
+
+    # Configure the mock to raise UnauthorizedException during folder browse
+    mock_supernote.web.list_query.side_effect = UnauthorizedException("Unauthorized")
+
+    config_entry = MockConfigEntry(
+        unique_id="user-identifier-1",
+        title="user-name",
+        domain=DOMAIN,
+        options={
+            CONF_USERNAME: "user-name",
+            CONF_ACCESS_TOKEN: "access-token-1",
+            CONF_TOKEN_TIMESTAMP: dt_util.now().timestamp(),
+            CONF_UNIQUE_ID: "user-identifier-1",
+            CONF_API_USERNAME: "user-name",
+            CONF_PASSWORD: "some-password",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    await async_setup_component(hass, "media_source", {})
+
+    # Mock login to also raise UnauthorizedException so token refresh fails
+    with patch(
+        "supernote.client.login_client.LoginClient.login",
+        side_effect=UnauthorizedException("Unauthorized refresh"),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Try to browse media, which should fail and trigger reauth
+        with pytest.raises(BrowseError, match="Authentication failed"):
+            await async_browse_media(
+                hass, "media-source://supernote_cloud/user-identifier-1/f/0"
+            )
+
+    # Verify that the reauth flow was started
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["handler"] == DOMAIN
+    assert flows[0]["context"]["source"] == "reauth"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -178,3 +178,73 @@ async def test_transcript_tool_call_error(
     result = await tool.async_call(hass, tool_input, AsyncMock())
 
     assert result == {"error": "Error fetching Supernote transcript: API Error"}
+
+
+@pytest.mark.usefixtures("mock_supernote")
+async def test_search_tool_auth_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_supernote: AsyncMock,
+):
+    """Test calling the search tool with an authentication error."""
+    from supernote.client.exceptions import UnauthorizedException
+    from custom_components.supernote_cloud.const import DOMAIN
+
+    # Ensure runtime_data is mock_supernote
+    config_entry.runtime_data = mock_supernote
+
+    mock_supernote.client.post_json = AsyncMock(
+        side_effect=UnauthorizedException("Unauthorized")
+    )
+
+    tool = SearchTool(config_entry)
+
+    tool_input = llm.ToolInput(
+        tool_name="search_supernote", tool_args={"query": "test query"}
+    )
+
+    result = await tool.async_call(hass, tool_input, AsyncMock())
+
+    assert result == {"error": "Supernote authentication failed: Unauthorized"}
+
+    # Verify that the reauth flow was started
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["handler"] == DOMAIN
+    assert flows[0]["context"]["source"] == "reauth"
+
+
+@pytest.mark.usefixtures("mock_supernote")
+async def test_transcript_tool_auth_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_supernote: AsyncMock,
+):
+    """Test calling the transcript tool with an authentication error."""
+    from supernote.client.exceptions import UnauthorizedException
+    from custom_components.supernote_cloud.const import DOMAIN
+
+    # Ensure runtime_data is mock_supernote
+    config_entry.runtime_data = mock_supernote
+
+    mock_supernote.client.post_json = AsyncMock(
+        side_effect=UnauthorizedException("Unauthorized")
+    )
+
+    tool = TranscriptTool(config_entry)
+
+    tool_input = llm.ToolInput(
+        tool_name="get_supernote_transcript", tool_args={"file_id": 12345}
+    )
+
+    result = await tool.async_call(hass, tool_input, AsyncMock())
+
+    assert result == {"error": "Supernote authentication failed: Unauthorized"}
+
+    # Verify that the reauth flow was started
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["handler"] == DOMAIN
+    assert flows[0]["context"]["source"] == "reauth"


### PR DESCRIPTION
This PR refactors the integration to handle 401 Unauthorized errors (UnauthorizedException) explicitly at the custom component boundaries (media_source, llm), keeping the external supernote library untouched.