### PR TITLE
fix: update supernote requirement to supernote[client]==0.17.0

### DIFF
--- a/custom_components/supernote_cloud/manifest.json
+++ b/custom_components/supernote_cloud/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/allenporter/home-assistant-supernote-cloud/issues",
-  "requirements": ["supernote==0.16.0"],
+  "requirements": ["supernote[client]==0.17.0"],
   "version": "0.10.0"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,4 @@ syrupy>=4.6.1
 # Component dependencies
 hassil>=3.2.0
 home-assistant-intents>=2025.9.24
-supernote==0.16.0
+supernote[client]==0.17.0


### PR DESCRIPTION
Update the supernote integration manifest and dev requirements to specify  so that optional client dependencies are included.